### PR TITLE
Cleans up RestLayerPrivilegesEvaluatorTest

### DIFF
--- a/src/test/java/org/opensearch/security/privileges/RestLayerPrivilegesEvaluatorTest.java
+++ b/src/test/java/org/opensearch/security/privileges/RestLayerPrivilegesEvaluatorTest.java
@@ -32,7 +32,6 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.security.securityconf.ConfigModel;
-import org.opensearch.security.securityconf.DynamicConfigModel;
 import org.opensearch.security.securityconf.SecurityRoles;
 import org.opensearch.security.user.User;
 import org.opensearch.threadpool.ThreadPool;
@@ -58,10 +57,6 @@ public class RestLayerPrivilegesEvaluatorTest {
     private ThreadPool threadPool;
     @Mock
     private ConfigModel configModel;
-    @Mock
-    private DynamicConfigModel dcm;
-    @Mock
-    private PrivilegesEvaluatorResponse presponse;
 
     private RestLayerPrivilegesEvaluator privilegesEvaluator;
 
@@ -73,7 +68,7 @@ public class RestLayerPrivilegesEvaluatorTest {
     }
 
     @Before
-    public void setUp() throws InstantiationException, IllegalAccessException {
+    public void setUp() {
         when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
 
         when(clusterService.localNode()).thenReturn(mock(DiscoveryNode.class, withSettings().strictness(Strictness.LENIENT)));
@@ -108,7 +103,7 @@ public class RestLayerPrivilegesEvaluatorTest {
     }
 
     @Test
-    public void testEvaluate_NotInitialized_NullModel_ExceptionThrown() throws Exception {
+    public void testEvaluate_NotInitialized_NullModel_ExceptionThrown() {
         // Null out the config model
         privilegesEvaluator.onConfigModelChanged(null);
         final OpenSearchSecurityException exception = assertThrows(
@@ -120,7 +115,7 @@ public class RestLayerPrivilegesEvaluatorTest {
     }
 
     @Test
-    public void testEvaluate_NotInitialized_NoSecurityRoles_ExceptionThrown() throws Exception {
+    public void testEvaluate_NotInitialized_NoSecurityRoles_ExceptionThrown() {
         final OpenSearchSecurityException exception = assertThrows(
             OpenSearchSecurityException.class,
             () -> privilegesEvaluator.evaluate(TEST_USER, null)


### PR DESCRIPTION
### Description
Cleans up unused code.


### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
